### PR TITLE
Fix for !candy command when no args are supplied

### DIFF
--- a/Twitch Pokemon System/scripts/games/pokemonSystem.js
+++ b/Twitch Pokemon System/scripts/games/pokemonSystem.js
@@ -1243,7 +1243,7 @@
                 }
                 if (command.equalsIgnoreCase('candy')) {
                     if (args.length == 0) {
-                        useCandy(sender, 1, getRandomOwnedIdFromUser(sender));
+                        $.say($.lang.get('pwaifugames.candy.owned', $.whisperPrefix(sender), getCandy(username)));
                     } else if (args.length == 1) {
                         useCandy(sender, 1, args.join(' '));
                     } else {

--- a/Twitch Pokemon System/scripts/lang/custom/games/games-pokemonSystem.js
+++ b/Twitch Pokemon System/scripts/lang/custom/games/games-pokemonSystem.js
@@ -9,6 +9,7 @@ $.lang.register('pwaifugames.profile.success', '$1 Progress: $5% - You own $2 ou
 $.lang.register('pwaifugames.reset.stats', '$1 your win and loss stats have been reset!');
 $.lang.register('pwaifugames.level.max', 'That character has reached the maximum level!');
 $.lang.register('pwaifugames.level.exceed', '$1 Using $2 Candy on $3 will exceed the 120000 EXP limit!');
+$.lang.register('pwaifugames.candy.owned', '$1 you have $2 candy!');
 $.lang.register('pwaifugames.candy.get', '$1 you have $2 Candy! Each candy restores a Pokémon\'s HP and increases EXP by: 100.');
 $.lang.register('pwaifugames.candy.missing', 'You don\'t have Pokémon!');
 $.lang.register('pwaifugames.candy.use', '$1 increased $2\'s EXP by $3! [EXP: $4] - (HP:$5 - Level: $6, Atk: $7, Def: $8). $9 candy left!');


### PR DESCRIPTION
Now correctly displays your candy amount instead of using a candy on a
random pokemon